### PR TITLE
Better installation process (in README)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -2,7 +2,7 @@
 
 == Installation
 
-    gem 'country_tools', :git => 'git://github.com/aurels/country_tools.git'
+    gem 'country_tools'
 
 == Supported languages
 


### PR DESCRIPTION
Since it's now released on Rubygems, it's best to use that version https://rubygems.org/gems/country_tools