### PR TITLE
Improve name consistency + add Croatia and remove Switzerland + fix bug

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -2,7 +2,7 @@
 
 == Installation
 
-    gem 'country_tools', :git => 'git://github.com/aurels/country_tools.git'
+    gem 'country_tools'
 
 == Supported languages
 
@@ -22,9 +22,9 @@ Get the name of a country by code [i18n aware] :
 
     CountryTools.name('BE') #=> 'Belgium'
 
-Ask if a country is in CEE :
+Ask if a country is in European Union :
 
-    CountryTools.in_cee?('BE') #=> true
+    CountryTools.in_eu?('BE') #=> true
 
 Get options for a select (inside form_for) :
 

--- a/lib/country_tools.rb
+++ b/lib/country_tools.rb
@@ -4,10 +4,45 @@ module CountryTools
     @@all_countries ||= YAML.load(File.read(path))
   end
 
-  CEE_CODES = %w[ DE AT BE BG CY DK ES EE FI FR EL HU IE IT LV LT LU MT NL PL PT GB RO SK SI SE CZ ]
+  # https://en.wikipedia.org/wiki/European_Union
+  EU_CODES = [
+    'AT',       # Austria
+    'BE',       # Belgium
+    'BG',       # Bulgaria
+    'HR',       # Croatia
+    'CY',       # Cyprus
+    'CZ',       # Czech Republic
+    'DK',       # Denmark
+    'EE',       # Estonia
+    'FI',       # Finland
+    'FR',       # France
+    'DE',       # Germany
+    'GR', 'EL', # Greece (https://fr.wikipedia.org/wiki/Union_europ%C3%A9enne#cite_ref-79)
+    'HU',       # Hungary
+    'IE',       # Ireland
+    'IT',       # Italy
+    'LV',       # Latvia
+    'LT',       # Lithuania
+    'LU',       # Luxembourg
+    'MT',       # Malta
+    'NL',       # Netherlands
+    'PL',       # Poland
+    'PT',       # Portugal
+    'RO',       # Romania
+    'SK',       # Slovakia
+    'SI',       # Slovenia
+    'ES',       # Spain
+    'SE',       # Sweden
+    'GB', 'UK', # United Kingdom (https://fr.wikipedia.org/wiki/Union_europ%C3%A9enne#cite_ref-81)
+  ]
+
+  def self.in_eu?(code)
+    EU_CODES.include?(code)
+  end
 
   def self.in_cee?(code)
-    CEE_CODES.include?(code)
+    warn "[DEPRECATION] `in_cee?` is deprecated. Please use `in_eu?` instead."
+    in_eu?(code)
   end
 
   def self.options_for_select

--- a/names.yml
+++ b/names.yml
@@ -270,6 +270,10 @@ GR:
   fr: Grèce
   en: Greece
   es: Grecia
+EL: # https://www.quora.com/Why-is-Greeces-country-code-EL-in-the-European-Union-but-GR-everywhere-else
+  fr: Grèce
+  en: Greece
+  es: Grecia
 GD:
   fr: Grenade
   en: Grenada
@@ -751,6 +755,10 @@ AE:
   en: United Arab Emirates
   es: Emiratos Árabes Unidos
 GB:
+  fr: Royaume-Uni
+  en: United Kingdom
+  es: Reino Unido
+UK: # Though GB is the United Kingdom's ISO 3166-1 alpha-2 code, UK is exceptionally reserved for the United Kingdom on the request of the country. (https://en.wikipedia.org/wiki/ISO_3166-2:GB)
   fr: Royaume-Uni
   en: United Kingdom
   es: Reino Unido


### PR DESCRIPTION
 * Rename `in_cee?` to `in_eu?` because cee dosn't exist anymore and had only 12 countries. European Union is what we want here (for vat intracom)
 * Remove Switzerland from EU countries
 * Add Croatia to EU countries (2013).
 * Add alternative codes for Greece (EL/GR) and United Kingdom (UK,GB) because of inconsistencies between UE codes and YAML
